### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
 
 name: Run tests
 
+permissions:
+  contents: read
+
 jobs:
   test:
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/frankywahl/super_hooks/security/code-scanning/2](https://github.com/frankywahl/super_hooks/security/code-scanning/2)

Add an explicit `permissions` block to `.github/workflows/ci.yml` at the workflow root (near `name` and before `jobs`) so all jobs inherit least-privilege defaults unless overridden.  
For this workflow, the best non-breaking baseline is:

- `contents: read`

This is sufficient for checkout and typical CI read operations, and does not change intended functionality while preventing accidental write access via `GITHUB_TOKEN`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
